### PR TITLE
Creates test, route, destroy action, happy and sad paths for us9

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -23,11 +23,11 @@ module Api
       end
 
       def destroy
-        @market_vendor = MarketVendor.find_by(market_id: params[:market_id], vendor_id: params[:vendor_id])
-        if @market_vendor
+        begin
+          @market_vendor = MarketVendor.find_by!(market_id: params[:market_id], vendor_id: params[:vendor_id])
           @market_vendor.destroy
           render json: "", status: 204
-        else
+        rescue ActiveRecord::RecordNotFound
           render json: { error: "No MarketVendor with market_id=#{params[:market_id]} AND vendor_id=#{params[:vendor_id]} exists" }, status: 404
         end
       end

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -1,6 +1,10 @@
 module Api
   module V0
     class MarketVendorsController < ApplicationController
+      # def index
+      #   @market = Market.find(params[:market_id])
+      #   @market_vendors = @market.market_vendors
+      # end
 
       def create
         if params[:market_id].empty? || params[:vendor_id].empty?
@@ -17,6 +21,17 @@ module Api
         @market_vendor = MarketVendor.create!(market_vendor_params)
         render json: MarketVendorSerializer.new(@market_vendor), status: 201
       end
+
+      def destroy
+        @market_vendor = MarketVendor.find_by(market_id: params[:market_id], vendor_id: params[:vendor_id])
+        if @market_vendor
+          @market_vendor.destroy
+          render json: "", status: 204
+        else
+          render json: { error: "No MarketVendor with market_id=#{params[:market_id]} AND vendor_id=#{params[:vendor_id]} exists" }, status: 404
+        end
+      end
+
     
       private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
         )
       end
       resources :market_vendors, only: %i[create]
+      delete "/market_vendors", to: "market_vendors#destroy"
     end
   end
 end

--- a/spec/requests/api/v0/market_vendors/market_vendors_delete_spec.rb
+++ b/spec/requests/api/v0/market_vendors/market_vendors_delete_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "delete a market vendor" do
+  before(:each) do
+    @market = create(:market)
+    @vendor = create(:vendor)
+    @market_vendor = MarketVendor.create!(market_id: @market.id, vendor_id: @vendor.id)
+  end
+
+  it 'can delete a market vendor' do
+    delete("/api/v0/market_vendors",
+      headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+      params: {
+        market_id: @market.id,
+        vendor_id: @vendor.id
+    }.to_json
+    )
+    expect(MarketVendor.count).to eq(0)
+
+    expect(response).to have_http_status(204)
+
+    expect(response.body).to eq("")
+  end
+
+  it 'returns status 404 and an error message if trying to find the vendor at a market that was deleted' do
+    delete("/api/v0/market_vendors",
+    headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+    params: {
+      market_id: @market.id,
+      vendor_id: @vendor.id
+    }.to_json
+    )
+
+    delete("/api/v0/market_vendors",
+    headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+    params: {
+      market_id: @market.id,
+      vendor_id: @vendor.id
+    }.to_json
+    )
+
+    expect(response).to have_http_status(404)
+    body = JSON.parse(response.body, symbolize_names: true)
+
+    expect(body).to have_key(:error)
+    expect(body[:error]).to be_a(String)
+    expect(body[:error]).to eq("No MarketVendor with market_id=#{@market.id} AND vendor_id=#{@vendor.id} exists")
+  end
+end

--- a/spec/requests/api/v0/market_vendors/market_vendors_delete_spec.rb
+++ b/spec/requests/api/v0/market_vendors/market_vendors_delete_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "delete a market vendor" do
         vendor_id: @vendor.id
     }.to_json
     )
+
     expect(MarketVendor.count).to eq(0)
 
     expect(response).to have_http_status(204)
@@ -42,6 +43,7 @@ RSpec.describe "delete a market vendor" do
     expect(response).to have_http_status(404)
     body = JSON.parse(response.body, symbolize_names: true)
 
+    expect(body).to be_a(Hash)
     expect(body).to have_key(:error)
     expect(body[:error]).to be_a(String)
     expect(body[:error]).to eq("No MarketVendor with market_id=#{@market.id} AND vendor_id=#{@vendor.id} exists")


### PR DESCRIPTION
i did not use the errorserializer or any of the error methods we created for this delete endpoint, not sure if we were trying to use that specifically. I was able to find a way to use begin and rescue and using find_by! which triggers the rescue if a market vendor with the params is not found, which then uses the acticerecord::recordnotfound error handling. 